### PR TITLE
Fix: `.wp-env bin/setup.sh` blog description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `brace-expansion` regular expression DOS vulnerability.
 - Fix `eslint/plugin-kit` regular expression DOS vulnerability.
+- Fix `bin/setup.sh` blog description.
 
 ## 1.0.8
 

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -254,6 +254,10 @@ export const createPluginFiles = async props => {
 					/"WordPress Site"/g,
 					`"${name}"`
 				);
+				fileContent = fileContent.replace(
+					/"A WordPress site for plugin devlopment by Sculpt."/g,
+					`"${description}"`
+				);
 				break;
 
 			case 'package.json':


### PR DESCRIPTION
This PR resolves #3.

## Description / Background Context

The blog description displayed in the **.wp-env** `setup.sh` file when the user runs the `sculpt plugin` command is always showing the default fallback description, even if a user supplies a custom description during setup.

```bash
wp-env run cli wp option update blogdescription "A WordPress site for plugin devlopment by Sculpt."
```

## Reproducible Steps

- Run `sculpt plugin` command.
- Make sure to provide a custom description for the plugin.
- Observe that when plugin is generated, the `setup.sh` file contains the fallback description and not the custom one the user just added.

## Expected Behaviour

If a user supplies a custom description, then that is supposed to be used instead of the fallback description. This needs to be fixed.

## Testing Instructions

- Repeat steps as above.
- Observe that the fallback description now contains the custom text the user provided during setup.