### PR TITLE
Feat: Add missing `.deployignore` config

### DIFF
--- a/repo/.deployignore
+++ b/repo/.deployignore
@@ -1,0 +1,8 @@
+.editorconfig
+.gitignore
+.wp-env.json
+package.json
+phpcs.xml
+phpunit.xml
+README.md
+tests

--- a/src/plugin/utils.js
+++ b/src/plugin/utils.js
@@ -67,6 +67,7 @@ export const getPluginDefaults = name => {
  */
 export const getPluginFiles = () => {
 	return [
+		'.deployignore',
 		'.editorconfig',
 		'.npmignore',
 		'.gitignore',


### PR DESCRIPTION
This PR resolves #4.

## Description / Background Context

At the moment, the `.deployignore` config file is missing in the plugin setup process. At a minimum, this file is important for the CI/CD **build** workflow and would need to be added to the plugin setup process.

This PR resolves this.

## Testing Instructions

- Repeat steps as above.
- Observe that the `.deployignore` config file is in place for use.